### PR TITLE
fix: add missing return statement for short version output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,8 @@ var versionCmd = &cobra.Command{
 		if short, _ := cmd.Flags().GetBool("short"); short {
 			// Print only the version number
 			fmt.Println(version)
+
+			return
 		}
 
 		// Print version information in a standardized format


### PR DESCRIPTION
`depup version -s` accidentally printed both, short and long version